### PR TITLE
Fix categories with spaces as the context[@category] also needs converting

### DIFF
--- a/lib/jekyll-categories.rb
+++ b/lib/jekyll-categories.rb
@@ -113,7 +113,7 @@ module Jekyll
         base_url = context.registers[:site].config['base-url'] || '/'
         category_dir = context.registers[:site].config['category_dir'] || 'categories'
 
-        category = context[@category] || @category.strip.tr(' ', '-').downcase
+        category = (context[@category] || @category).strip.tr(' ', '-').downcase
         category.empty? ? "#{base_url}#{category_dir}" : "#{base_url}#{category_dir}/#{category}"
       end
     end


### PR DESCRIPTION
When using this code, the category url did not replace spaces with dashes. The added parentheses in this pull request resolved the issue.

``` html
{% for category in site.categories %}
  <a href="{% category_url category.first %}">{{ category.first }}</a>
{% endfor %}
```
